### PR TITLE
Swift 6, Fixes, and Quality of life improvements

### DIFF
--- a/.swiftpm/build-and-run.sh
+++ b/.swiftpm/build-and-run.sh
@@ -2,7 +2,6 @@
 set -e
 (killall 'Playdate Simulator' || true) 2>/dev/null
 cd ..
-~/Developer/PlaydateSDK/bin/Playdate\ Simulator.app/Contents/MacOS/Playdate\ Simulator .build/plugins/PDCPlugin/outputs/$PRODUCT_NAME.pdx
 swift package pdc --product $PRODUCT_NAME
 
 # Create a symbolic link to the compiled pdx in the Playdate Simulator Games dir
@@ -13,3 +12,5 @@ then
 fi
 ln -s "$(pwd)/.build/plugins/PDCPlugin/outputs/$PRODUCT_NAME.pdx" ~/Developer/PlaydateSDK/Disk/Games/$PRODUCT_NAME.pdx
 
+# Run the pdx in the Playdate Simulator
+~/Developer/PlaydateSDK/bin/Playdate\ Simulator.app/Contents/MacOS/Playdate\ Simulator ~/Developer/PlaydateSDK/Disk/Games/$PRODUCT_NAME.pdx

--- a/.swiftpm/build-and-run.sh
+++ b/.swiftpm/build-and-run.sh
@@ -2,5 +2,5 @@
 set -e
 (killall 'Playdate Simulator' || true) 2>/dev/null
 cd ..
-swift package pdc
 ~/Developer/PlaydateSDK/bin/Playdate\ Simulator.app/Contents/MacOS/Playdate\ Simulator .build/plugins/PDCPlugin/outputs/$PRODUCT_NAME.pdx
+swift package pdc --product $PRODUCT_NAME

--- a/.swiftpm/build-and-run.sh
+++ b/.swiftpm/build-and-run.sh
@@ -4,3 +4,12 @@ set -e
 cd ..
 ~/Developer/PlaydateSDK/bin/Playdate\ Simulator.app/Contents/MacOS/Playdate\ Simulator .build/plugins/PDCPlugin/outputs/$PRODUCT_NAME.pdx
 swift package pdc --product $PRODUCT_NAME
+
+# Create a symbolic link to the compiled pdx in the Playdate Simulator Games dir
+# This allows browsing the pdx as a sideloaded game, helpful for checking icons
+if [ -e ~/Developer/PlaydateSDK/Disk/Games/$PRODUCT_NAME.pdx ]
+then
+    rm -rf ~/Developer/PlaydateSDK/Disk/Games/$PRODUCT_NAME.pdx
+fi
+ln -s "$(pwd)/.build/plugins/PDCPlugin/outputs/$PRODUCT_NAME.pdx" ~/Developer/PlaydateSDK/Disk/Games/$PRODUCT_NAME.pdx
+

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import Foundation
 import PackageDescription
@@ -19,6 +19,8 @@ let package = Package(
             ],
             swiftSettings: swiftSettings
         ),
+    ],
+    swiftLanguageModes: [.v6]
 )
 
 

--- a/Package.swift
+++ b/Package.swift
@@ -3,15 +3,6 @@
 import Foundation
 import PackageDescription
 
-let gccIncludePrefix =
-    "/usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/lib/gcc/arm-none-eabi/9.2.1"
-
-let playdateSDKPath: String
-if let path = Context.environment["PLAYDATE_SDK_PATH"] {
-    playdateSDKPath = path
-} else {
-    playdateSDKPath = "\(Context.environment["HOME"]!)/Developer/PlaydateSDK/"
-}
 
 let package = Package(
     name: "PlaydateKitTemplate",
@@ -23,21 +14,38 @@ let package = Package(
     targets: [
         .target(
             name: "PlaydateKitTemplate",
-            dependencies: [.product(name: "PlaydateKit", package: "PlaydateKit")],
-            swiftSettings: [
-                .enableExperimentalFeature("Embedded"),
-                .unsafeFlags([
-                    "-Xfrontend", "-disable-objc-interop",
-                    "-Xfrontend", "-disable-stack-protector",
-                    "-Xfrontend", "-function-sections",
-                    "-Xfrontend", "-gline-tables-only",
-                    "-Xcc", "-DTARGET_EXTENSION",
-                    "-Xcc", "-I", "-Xcc", "\(gccIncludePrefix)/include",
-                    "-Xcc", "-I", "-Xcc", "\(gccIncludePrefix)/include-fixed",
-                    "-Xcc", "-I", "-Xcc", "\(gccIncludePrefix)/../../../../arm-none-eabi/include",
-                    "-I", "\(playdateSDKPath)/C_API"
-                ]),
-            ]
-        )
-    ]
+            dependencies: [
+                .product(name: "PlaydateKit", package: "PlaydateKit")
+            ],
+            swiftSettings: swiftSettings
+        ),
 )
+
+
+// MARK: - Helper Variables
+// note: These must be computed variables when beneath the `let package =` declaration.
+
+var swiftSettings: [SwiftSetting] {[
+    .enableExperimentalFeature("Embedded"),
+    .unsafeFlags([
+        "-whole-module-optimization",
+        "-Xfrontend", "-disable-objc-interop",
+        "-Xfrontend", "-disable-stack-protector",
+        "-Xfrontend", "-function-sections",
+        "-Xfrontend", "-gline-tables-only",
+        "-Xcc", "-DTARGET_EXTENSION",
+        "-Xcc", "-I", "-Xcc", "\(gccIncludePrefix)/include",
+        "-Xcc", "-I", "-Xcc", "\(gccIncludePrefix)/include-fixed",
+        "-Xcc", "-I", "-Xcc", "\(gccIncludePrefix)/../../../../arm-none-eabi/include",
+        "-I", "\(playdateSDKPath)/C_API"
+    ]),
+]}
+var gccIncludePrefix: String {
+    "/usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/lib/gcc/arm-none-eabi/9.2.1"
+}
+var playdateSDKPath: String {
+    if let path = Context.environment["PLAYDATE_SDK_PATH"] {
+        return path
+    }
+    return "\(Context.environment["HOME"]!)/Developer/PlaydateSDK/"
+}


### PR DESCRIPTION
- Makes the package requires Swift 6
- Adds the `--product` argument introduced in https://github.com/finnvoor/PlaydateKit/pull/104
- Adds symlinks of built pdx to the Playdate Simulator to help with previewing marketing icons. The PDX shows as a sideloaded game on the Home Screen.
- Moves the Package.swift helper variables to the bottom of the source and makes the computed variables to eliminate a bug where the environment is not filled before the variables are computed causing build errors.