### PR TITLE
Add Playdate SDK include path for Xcode module scanning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,12 @@ import PackageDescription
 /// Xcode gains toolset.json support.
 let xcode = (Context.environment["XPC_SERVICE_NAME"]?.count ?? 0) > 2
 
+let playdateSDKPath: String = if let path = Context.environment["PLAYDATE_SDK_PATH"] {
+    path
+} else {
+    "\(Context.environment["HOME"]!)/Developer/PlaydateSDK/"
+}
+
 let package = Package(
     name: "PlaydateKitTemplate",
     platforms: [.macOS(.v14)],
@@ -28,7 +34,8 @@ let package = Package(
                     "-Xfrontend", "-disable-stack-protector",
                     "-Xfrontend", "-function-sections",
                     "-Xfrontend", "-gline-tables-only",
-                    "-Xcc", "-DTARGET_EXTENSION"
+                    "-Xcc", "-DTARGET_EXTENSION",
+                    "-Xcc", "-I", "-Xcc", "\(playdateSDKPath)/C_API",
                 ]),
             ],
         )


### PR DESCRIPTION
## Summary
- Adds the Playdate SDK `C_API` include path (`-Xcc -I`) to the target's `swiftSettings`
- Fixes Xcode builds failing with `'pd_api.h' file not found` during Clang dependency scanning
- The CPlaydate target's `cSettings` uses `.unsafeFlags` for the SDK include path, which doesn't propagate to dependent targets during Xcode's explicit module builds
